### PR TITLE
feat(ci): split translate workflow into Issue-trigger + writer

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,6 +19,7 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       ) && !(github.event_name == 'issues' && contains(toJSON(github.event.issue.labels), '"auto-blog"'))
+        && !(github.event_name == 'issues' && contains(toJSON(github.event.issue.labels), '"auto-translate"'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/translate-writer.yml
+++ b/.github/workflows/translate-writer.yml
@@ -1,0 +1,97 @@
+name: Translate Writer
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  translate:
+    if: contains(toJSON(github.event.issue.labels), '"auto-translate"')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Fetch build data
+        run: node scripts/fetch-build-data.mjs
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        continue-on-error: true
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: >-
+            --allowed-tools
+            "Bash(git:*)"
+            "Bash(gh:*)"
+            "Bash(mkdir:*)"
+            "Bash(node:*)"
+            "Bash(date:*)"
+            "Read"
+            "Write"
+            "Edit"
+            "Glob"
+            "Grep"
+
+      - name: Rewrite commit author and create PR
+        env:
+          GH_TOKEN: ${{ secrets.PAT_GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          # Find the branch Claude pushed
+          BRANCH=$(git ls-remote --heads origin "claude/issue-${ISSUE_NUMBER}-*" \
+            | awk '{print $2}' | sed 's|refs/heads/||' | sort -r | head -1)
+
+          if [ -z "$BRANCH" ]; then
+            echo "No branch found for issue #${ISSUE_NUMBER}, skipping PR creation"
+            exit 0
+          fi
+          echo "Found branch: $BRANCH"
+
+          # Rewrite commit author to translator-bot
+          git config user.name "translator-bot"
+          git config user.email "translator-bot@nologin.tools"
+          REPO="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "$REPO"
+          git fetch origin "$BRANCH"
+          git checkout "$BRANCH"
+          git commit --amend --author="translator-bot <translator-bot@nologin.tools>" --no-edit
+          git push origin "$BRANCH" --force
+
+          # Check if PR already exists
+          EXISTING=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$EXISTING" ]; then
+            echo "PR #$EXISTING already exists, skipping"
+            exit 0
+          fi
+
+          # Create PR
+          PR_URL=$(gh pr create \
+            --head "$BRANCH" \
+            --title "i18n: auto-translate content" \
+            --body "Auto-generated translation update.
+
+          Closes #${ISSUE_NUMBER}" \
+            --label "auto-translate" \
+            --base main)
+
+          echo "Created PR: $PR_URL"
+
+          # Enable auto-merge
+          gh pr merge --auto --squash "$PR_URL" || echo "Auto-merge not available (branch protection may not be configured)"

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -15,17 +15,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  translate:
+  check-and-create-issue:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
       issues: write
-      id-token: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
@@ -41,79 +36,76 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         continue-on-error: true
 
-      - name: Configure git author
-        run: |
-          git config user.name "translator-bot"
-          git config user.email "translator-bot@nologin.tools"
-
       - name: Check if translation needed
         id: check
         run: node scripts/check-translation-needed.mjs
 
-      - name: Translate content
+      - name: Check for existing open Issue
         if: steps.check.outputs.needs_translation == 'true'
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            You are a translation agent for nologin.tools.
-            Target languages: zh, ja, ko, es, fr, de, pt.
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.PAT_GITHUB_TOKEN }}
+        run: |
+          OPEN=$(gh issue list --label "auto-translate" --state open --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$OPEN" ]; then
+            echo "Open auto-translate issue #$OPEN already exists, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
-            ## Task 1: UI Strings
-            Read src/i18n/en.json. Compute its SHA-256 hash (first 16 hex chars).
-            For each target locale, read src/i18n/{locale}.json:
-            - If `_sourceHash` differs from current en.json hash → re-translate ALL keys
-            - If `_sourceHash` matches → only translate keys missing in locale file
-            - Keep brand names (nologin.tools, NoLoginTools.org) untranslated
-            - Preserve {placeholder} syntax exactly
-            - Store updated `_sourceHash` as the first key in each locale file
-            - Write valid JSON with 2-space indentation
+      - name: Create translation Issue
+        if: steps.check.outputs.needs_translation == 'true' && steps.existing.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_GITHUB_TOKEN }}
+        run: |
+          cat > /tmp/translate-issue-body.md << 'ISSUE_BODY'
+          You are a translation agent for nologin.tools.
+          Target languages: zh, ja, ko, es, fr, de, pt.
 
-            ## Task 2: Blog Posts
-            Scan src/content/blog/*.md (root-level only = English sources).
-            For each post and each locale, check src/content/blog/{locale}/{filename}:
-            - If translation missing → translate full Markdown, create the directory if needed
-            - If translation exists but `sourceHash` in frontmatter differs from
-              current English content hash → re-translate (content was updated)
-            - Translate title and description in frontmatter
-            - Add locale, originalSlug, sourceHash to frontmatter
-            - Keep all links, code blocks, brand names, and URLs unchanged
-            - Keep the same Markdown structure (headings, lists, etc.)
+          ## Task 1: UI Strings
+          Read src/i18n/en.json. Compute its SHA-256 hash (first 16 hex chars).
+          For each target locale, read src/i18n/{locale}.json:
+          - If `_sourceHash` differs from current en.json hash → re-translate ALL keys
+          - If `_sourceHash` matches → only translate keys missing in locale file
+          - Keep brand names (nologin.tools, NoLoginTools.org) untranslated
+          - Preserve {placeholder} syntax exactly
+          - Store updated `_sourceHash` as the first key in each locale file
+          - Write valid JSON with 2-space indentation
 
-            ## Task 3: Tool Descriptions (if build-data.json exists)
-            Read src/data/build-data.json if it exists. For each approved tool and each locale,
-            check src/data/translations/{locale}.json:
-            - Compute SHA-256 hash (first 16 chars) of English description+"|"+coreTask
-            - If tool missing or `_hash` differs → translate description and coreTask
-            - Keep tool names in English
-            - Store `_hash` alongside each translation
-            - Write valid JSON with 2-space indentation
+          ## Task 2: Blog Posts
+          Scan src/content/blog/*.md (root-level only = English sources).
+          For each post and each locale, check src/content/blog/{locale}/{filename}:
+          - If translation missing → translate full Markdown, create the directory if needed
+          - If translation exists but `sourceHash` in frontmatter differs from
+            current English content hash → re-translate (content was updated)
+          - Translate title and description in frontmatter
+          - Add locale, originalSlug, sourceHash to frontmatter
+          - Keep all links, code blocks, brand names, and URLs unchanged
+          - Keep the same Markdown structure (headings, lists, etc.)
 
-            ## Translation Quality Guidelines
-            - Use natural, fluent language appropriate for each locale
-            - Maintain technical accuracy
-            - Do NOT translate: brand names, URLs, code snippets, {placeholders}
-            - For Chinese (zh): use Simplified Chinese
-            - For Portuguese (pt): use Brazilian Portuguese
+          ## Task 3: Tool Descriptions (if build-data.json exists)
+          Read src/data/build-data.json if it exists. For each approved tool and each locale,
+          check src/data/translations/{locale}.json:
+          - Compute SHA-256 hash (first 16 chars) of English description+"|"+coreTask
+          - If tool missing or `_hash` differs → translate description and coreTask
+          - Keep tool names in English
+          - Store `_hash` alongside each translation
+          - Write valid JSON with 2-space indentation
 
-            ## After translating:
-            If any files were changed:
-            1. Configure git author:
-               git config user.name "translator-bot"
-               git config user.email "translator-bot@nologin.tools"
-            2. Create a new branch named i18n/auto-translate-$(date +%Y%m%d)
-            3. Commit all changes with message "i18n: auto-translate content"
-            4. Create a PR targeting main with title "i18n: auto-translate content" and auto-merge with squash
-            If no changes needed, just report "All translations up to date" and exit.
-          claude_args: >-
-            --allowed-tools
-            "Bash(git:*)"
-            "Bash(gh:*)"
-            "Bash(mkdir:*)"
-            "Bash(node:*)"
-            "Bash(date:*)"
-            "Read"
-            "Write"
-            "Edit"
-            "Glob"
-            "Grep"
+          ## Translation Quality Guidelines
+          - Use natural, fluent language appropriate for each locale
+          - Maintain technical accuracy
+          - Do NOT translate: brand names, URLs, code snippets, {placeholders}
+          - For Chinese (zh): use Simplified Chinese
+          - For Portuguese (pt): use Brazilian Portuguese
+
+          ## Important
+          - Only modify translation files. Do NOT modify any English source files.
+          - If no changes are needed, report "All translations up to date" and exit.
+          ISSUE_BODY
+
+          gh issue create \
+            --title "[Auto Translate] $(date +%Y-%m-%d)" \
+            --body-file /tmp/translate-issue-body.md \
+            --label "auto-translate"


### PR DESCRIPTION
## Summary
- Refactor `translate.yml` from directly calling `claude-code-action` (which doesn't support `push` events) to creating an `auto-translate` Issue
- Add `translate-writer.yml` that triggers on `auto-translate` Issue, runs `claude-code-action`, rewrites commit author to `translator-bot`, and creates a PR with auto-merge
- Add duplicate Issue guard to prevent creating multiple `auto-translate` Issues when a previous one is still open
- Exclude `auto-translate` label from `claude.yml` to avoid duplicate triggers

## Test plan
- [ ] Manual trigger `translate.yml` (workflow_dispatch) → verify `auto-translate` Issue is created
- [ ] Verify `translate-writer.yml` triggers on the Issue and Claude translates correctly
- [ ] Verify PR commit author is `translator-bot <translator-bot@nologin.tools>`
- [ ] Verify `claude.yml` does not trigger on `auto-translate` Issues
- [ ] Trigger again while an Issue is still open → verify no duplicate Issue created