### PR TITLE
fix(ci): add @claude trigger phrase to translate Issue body

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -60,7 +60,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT_GITHUB_TOKEN }}
         run: |
           cat > /tmp/translate-issue-body.md << 'ISSUE_BODY'
-          You are a translation agent for nologin.tools.
+          @claude You are a translation agent for nologin.tools.
           Target languages: zh, ja, ko, es, fr, de, pt.
 
           ## Task 1: UI Strings


### PR DESCRIPTION
## Summary
- `claude-code-action` requires `@claude` in the Issue body to trigger execution
- Without it, the action logs `No trigger found, skipping remaining steps` and exits immediately
- Add `@claude` prefix to the translate Issue body, matching the blog pipeline pattern

## Test plan
- [ ] Close existing auto-translate Issue #14
- [ ] Re-trigger `translate.yml` → verify new Issue contains `@claude`
- [ ] Verify `translate-writer.yml` actually runs Claude this time