### PR TITLE
feat(seo): RSS feed, cache headers, structured data & sitemap images

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,9 @@ scripts/
     ├── check-translation-needed.test.mjs # Change manifest generation tests (22 cases)
     ├── generate-translate-issue.test.mjs # Issue body generation tests (15 cases)
     ├── i18n-utils.test.mjs       # i18n utility function tests (29 cases)
-    └── sitemap.test.mjs          # Sitemap multi-locale generation tests (20 cases)
+    ├── sitemap.test.mjs          # Sitemap multi-locale generation tests (23 cases)
+    ├── rss.test.mjs              # RSS feed generation tests (10 cases)
+    └── headers.test.mjs          # Cache-Control headers validation tests (8 cases)
 src/
 ├── i18n/
 │   ├── config.ts         # Locale constants, types, labels, OG locale map
@@ -91,7 +93,8 @@ src/
 │   ├── ssr/[lang]/tool/[slug].astro   # ★ Multi-language ISR fallback
 │   ├── ssr/[lang]/badge/[slug].astro  # ★ Multi-language ISR fallback
 │   ├── admin/index.astro     # Full admin dashboard (SSR, secret-protected)
-│   ├── sitemap.xml.ts        # Static (with xhtml:link for all locales)
+│   ├── sitemap.xml.ts        # Static (with xhtml:link for all locales, image:image extension)
+│   ├── rss.xml.ts            # Static RSS 2.0 feed (English blog posts)
 │   └── api/              # submit, review, edit, resubmit, tools/[slug], admin/*, og/[slug]
 ├── middleware.ts          # ISR rewrite logic + Cache API + Accept-Language redirect
 sites/org/                # NologinTools.org — organization authority site (independent Astro project)
@@ -106,6 +109,7 @@ workers/cron/             # Health checks, badge detection, data export
 | `/tool/[slug]` | Static + ISR | Known: `getStaticPaths()` / New: SSR fallback `/ssr/tool/[slug]` |
 | `/badge/[slug]` | Static + ISR | Known: `getStaticPaths()` / New: SSR fallback `/ssr/badge/[slug]` |
 | `/sitemap.xml` | Static | `loader.ts` (build data) |
+| `/rss.xml` | Static | Content Collection (`getCollection('blog')`) |
 | `/blog` | Static | Content Collection (`getCollection('blog')`) |
 | `/blog/[slug]` | Static | Content Collection + `render()` |
 | `/{lang}/` (all pages) | Static | Same as English + locale prop |
@@ -201,12 +205,17 @@ workers/cron/             # Health checks, badge detection, data export
 - **SEO — Web App Manifest**: `public/site.webmanifest` with minimal config, linked from Layout `<head>`.
 - **SEO — robots.txt**: `public/robots.txt` blocks `/admin`, `/api/`, `/ssr/` from crawlers and declares sitemap location.
 - **SEO — OG image**: Default OG image is `public/og-default.png` (1200×630, brand logo + tagline). Layout defaults to `/og-default.png`. Dynamic per-tool OG images generated at `/api/og/[slug]` using `satori` + `@resvg/resvg-wasm` (SSR, 6h cache). Layout accepts `ogImagePath` prop; `ToolDetailPage` passes `/api/og/${slug}`.
-- **SEO — Layout props**: `Layout.astro` supports optional `canonicalOverride` (string path, resolves against `https://nologin.tools`), `publishedTime` (ISO date string for `article:published_time`), and `ogImagePath` (path for dynamic OG image). Canonical URL uses `Astro.url.pathname` to strip query params. `ToolDetailPage` and `BadgeDetailPage` use `canonicalOverride` to ensure ISR pages (`/ssr/tool/*`, `/ssr/badge/*`) point canonical to `/tool/*` and `/badge/*`.
+- **SEO — Layout props**: `Layout.astro` supports optional `canonicalOverride` (string path, resolves against `https://nologin.tools`), `publishedTime` (ISO date string for `article:published_time`), `modifiedTime` (ISO date string for `article:modified_time`), and `ogImagePath` (path for dynamic OG image). Canonical URL uses `Astro.url.pathname` to strip query params. `ToolDetailPage` and `BadgeDetailPage` use `canonicalOverride` to ensure ISR pages (`/ssr/tool/*`, `/ssr/badge/*`) point canonical to `/tool/*` and `/badge/*`.
 - **SEO — Sitemap multi-locale**: `sitemap.xml.ts` generates a `<url>` entry for every locale variant of every page (8 locales × N pages). Core logic extracted to `src/lib/sitemap.ts` (pure functions: `buildBlogTranslationMap`, `expandToAllLocales`, `generateHreflangLinks`). Non-blog pages expand to all 8 locales; blog posts only expand to locales with actual translations (determined by `buildBlogTranslationMap`). Each `<url>` includes hreflang links matching its available locales + `x-default` (English). Tests: `node --test scripts/__tests__/sitemap.test.mjs` (20 cases).
 - **SEO — Sitemap lastmod**: `sitemap.xml.ts` includes `<lastmod>` for tool/badge pages (from `approvedAt`). Static pages use build-time date.
-- **SEO — JSON-LD**: Homepage has `WebSite` + `SearchAction` (supports Sitelinks Searchbox). Tool detail pages have `SoftwareApplication` (with `offers`, `operatingSystem`, `datePublished`) + `BreadcrumbList`. Badge pages have `BreadcrumbList`. About page has `Organization`. Badge info page (`/badge`) has `FAQPage`.
+- **SEO — JSON-LD**: Homepage has `WebSite` + `SearchAction` (supports Sitelinks Searchbox). Tool detail pages have `SoftwareApplication` (with `offers`, `operatingSystem`, `datePublished`, `dateModified`) + `BreadcrumbList`. Badge pages have `BreadcrumbList`. About page has `Organization`. Badge info page (`/badge`) has `FAQPage` + `HowTo`. Blog list page has `Blog` + `BreadcrumbList`. Blog post pages have `BlogPosting` + `BreadcrumbList`.
 - **SEO — Meta tags**: Layout includes `og:site_name`, `og:locale`, `twitter:site` (`@nologin_tools`), explicit `twitter:title`/`twitter:description`/`twitter:image`, `og:image:width`/`og:image:height`/`og:image:alt`, `theme-color` (`#22c55e`), `<link rel="sitemap">`, and `<link rel="preconnect">` for Google Fonts.
 - **SEO — Security headers**: `public/_headers` sets `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` (no camera/mic/geo).
+- **SEO — Cache-Control**: `public/_headers` sets long-term cache for static assets: `/_astro/*` (1 year, immutable), `/blog/images/*` (30 days), `/favicon.svg`, `/og-default.png`, `/badges/*` (7 days each).
+- **SEO — RSS feed**: `rss.xml.ts` generates RSS 2.0 feed with `atom:link` self-reference, English blog posts only, sorted by date descending. Posts with `heroImageQuery` include `<enclosure>` for hero images. Layout `<head>` includes `<link rel="alternate" type="application/rss+xml">`. Footer has RSS link.
+- **SEO — HowTo schema**: `BadgeInfoPage.astro` includes `HowTo` JSON-LD alongside `FAQPage`, mapping the 4-step "For Creators" flow to `HowToStep` entries.
+- **SEO — Sitemap image extension**: `sitemap.xml.ts` includes `xmlns:image` namespace and `<image:image>` tags for tool pages (OG images) and blog posts (hero images).
+- **SEO — Blog OG images**: Blog posts with `heroImageQuery` use `/blog/images/{slug}/hero.jpg` as OG image instead of default. Multi-language posts use `originalSlug` to find the hero image.
 - **SEO — Breadcrumbs**: Tool detail pages and badge detail pages have visible HTML `<nav aria-label="Breadcrumb">` with structured `<ol>` lists. Tool: Home > {name}. Badge: Home > {name} > Verified/Pending.
 - **SEO — Accessibility**: Header nav elements have `aria-label` ("Main navigation" / "Mobile navigation"). Homepage category navigation has `aria-label` ("Category navigation").
 

--- a/public/_headers
+++ b/public/_headers
@@ -4,3 +4,18 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains
+
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/blog/images/*
+  Cache-Control: public, max-age=2592000
+
+/favicon.svg
+  Cache-Control: public, max-age=604800
+
+/og-default.png
+  Cache-Control: public, max-age=604800
+
+/badges/*
+  Cache-Control: public, max-age=604800

--- a/scripts/__tests__/headers.test.mjs
+++ b/scripts/__tests__/headers.test.mjs
@@ -1,0 +1,103 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const headersPath = resolve(__dirname, '../../public/_headers');
+
+function parseHeaders(content) {
+  const blocks = [];
+  let current = null;
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (!line.startsWith(' ') && !line.startsWith('\t')) {
+      // Path line
+      current = { path: trimmed, headers: [] };
+      blocks.push(current);
+    } else if (current) {
+      current.headers.push(trimmed);
+    }
+  }
+  return blocks;
+}
+
+// ===================== TESTS =====================
+
+describe('_headers file', () => {
+  let content;
+  let blocks;
+
+  it('can be read and parsed', () => {
+    content = readFileSync(headersPath, 'utf-8');
+    blocks = parseHeaders(content);
+    assert.ok(blocks.length > 0, 'Should have at least one path block');
+  });
+
+  it('has valid path block format (path followed by indented headers)', () => {
+    content = readFileSync(headersPath, 'utf-8');
+    blocks = parseHeaders(content);
+    for (const block of blocks) {
+      assert.ok(block.path, 'Block should have a path');
+      assert.ok(block.headers.length > 0, `Block "${block.path}" should have at least one header`);
+    }
+  });
+
+  it('/_astro/* has immutable cache directive', () => {
+    content = readFileSync(headersPath, 'utf-8');
+    blocks = parseHeaders(content);
+    const astroBlock = blocks.find((b) => b.path === '/_astro/*');
+    assert.ok(astroBlock, '/_astro/* block should exist');
+    const cacheHeader = astroBlock.headers.find((h) => h.startsWith('Cache-Control:'));
+    assert.ok(cacheHeader, 'Cache-Control header should exist');
+    assert.ok(cacheHeader.includes('immutable'), 'Should include immutable directive');
+    assert.ok(cacheHeader.includes('max-age=31536000'), 'Should have 1 year max-age');
+  });
+
+  it('/* security headers still exist (regression)', () => {
+    content = readFileSync(headersPath, 'utf-8');
+    blocks = parseHeaders(content);
+    const globalBlock = blocks.find((b) => b.path === '/*');
+    assert.ok(globalBlock, '/* block should exist');
+    const headerNames = globalBlock.headers.map((h) => h.split(':')[0].trim());
+    assert.ok(headerNames.includes('X-Frame-Options'), 'X-Frame-Options should exist');
+    assert.ok(headerNames.includes('X-Content-Type-Options'), 'X-Content-Type-Options should exist');
+    assert.ok(headerNames.includes('Strict-Transport-Security'), 'HSTS should exist');
+    assert.ok(headerNames.includes('Referrer-Policy'), 'Referrer-Policy should exist');
+    assert.ok(headerNames.includes('Permissions-Policy'), 'Permissions-Policy should exist');
+  });
+
+  it('/blog/images/* has cache header', () => {
+    content = readFileSync(headersPath, 'utf-8');
+    blocks = parseHeaders(content);
+    const blogBlock = blocks.find((b) => b.path === '/blog/images/*');
+    assert.ok(blogBlock, '/blog/images/* block should exist');
+    const cacheHeader = blogBlock.headers.find((h) => h.startsWith('Cache-Control:'));
+    assert.ok(cacheHeader, 'Cache-Control header should exist for blog images');
+  });
+
+  it('/badges/* has cache header', () => {
+    content = readFileSync(headersPath, 'utf-8');
+    blocks = parseHeaders(content);
+    const badgesBlock = blocks.find((b) => b.path === '/badges/*');
+    assert.ok(badgesBlock, '/badges/* block should exist');
+    const cacheHeader = badgesBlock.headers.find((h) => h.startsWith('Cache-Control:'));
+    assert.ok(cacheHeader, 'Cache-Control header should exist for badges');
+  });
+
+  it('/favicon.svg has cache header', () => {
+    content = readFileSync(headersPath, 'utf-8');
+    blocks = parseHeaders(content);
+    const faviconBlock = blocks.find((b) => b.path === '/favicon.svg');
+    assert.ok(faviconBlock, '/favicon.svg block should exist');
+  });
+
+  it('/og-default.png has cache header', () => {
+    content = readFileSync(headersPath, 'utf-8');
+    blocks = parseHeaders(content);
+    const ogBlock = blocks.find((b) => b.path === '/og-default.png');
+    assert.ok(ogBlock, '/og-default.png block should exist');
+  });
+});

--- a/scripts/__tests__/rss.test.mjs
+++ b/scripts/__tests__/rss.test.mjs
@@ -1,0 +1,146 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Reimplement RSS helpers in pure JS for testability
+
+function toRFC822(date) {
+  return date.toUTCString();
+}
+
+function escapeXml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function generateRssXml(posts, siteUrl = 'https://nologin.tools') {
+  const englishPosts = posts
+    .filter((p) => !p.id.includes('/'))
+    .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
+
+  const items = englishPosts
+    .map((post) => {
+      const link = escapeXml(`${siteUrl}/blog/${post.id}`);
+      const enclosure = post.data.heroImageQuery
+        ? `\n      <enclosure url="${escapeXml(`${siteUrl}/blog/images/${post.id}/hero.jpg`)}" length="0" type="image/jpeg" />`
+        : '';
+      return `    <item>
+      <title>${escapeXml(post.data.title)}</title>
+      <link>${link}</link>
+      <description>${escapeXml(post.data.description)}</description>
+      <pubDate>${toRFC822(post.data.publishedAt)}</pubDate>
+      <guid>${link}</guid>${enclosure}
+    </item>`;
+    })
+    .join('\n');
+
+  const lastBuildDate = englishPosts.length > 0 ? toRFC822(englishPosts[0].data.publishedAt) : toRFC822(new Date());
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>nologin.tools Blog</title>
+    <link>${siteUrl}/blog</link>
+    <description>Privacy-friendly tools that work without login — reviews, guides, and updates.</description>
+    <language>en</language>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+    <atom:link href="${siteUrl}/rss.xml" rel="self" type="application/rss+xml" />
+${items}
+  </channel>
+</rss>`;
+}
+
+// ===================== TESTS =====================
+
+describe('RSS feed generation', () => {
+  it('generates valid RSS XML with multiple posts', () => {
+    const posts = [
+      { id: 'post-a', data: { title: 'Post A', description: 'Desc A', publishedAt: new Date('2026-01-15'), tags: [] } },
+      { id: 'post-b', data: { title: 'Post B', description: 'Desc B', publishedAt: new Date('2026-02-01'), tags: [] } },
+    ];
+    const xml = generateRssXml(posts);
+    assert.ok(xml.startsWith('<?xml version="1.0"'));
+    assert.ok(xml.includes('<rss version="2.0"'));
+    assert.ok(xml.includes('<title>Post A</title>'));
+    assert.ok(xml.includes('<title>Post B</title>'));
+    assert.ok(xml.includes('</channel>'));
+    assert.ok(xml.includes('</rss>'));
+  });
+
+  it('sorts posts by date descending', () => {
+    const posts = [
+      { id: 'older', data: { title: 'Older', description: 'D', publishedAt: new Date('2026-01-01'), tags: [] } },
+      { id: 'newer', data: { title: 'Newer', description: 'D', publishedAt: new Date('2026-03-01'), tags: [] } },
+    ];
+    const xml = generateRssXml(posts);
+    const newerIdx = xml.indexOf('<title>Newer</title>');
+    const olderIdx = xml.indexOf('<title>Older</title>');
+    assert.ok(newerIdx < olderIdx, 'Newer post should appear before older post');
+  });
+
+  it('generates RFC 822 date format', () => {
+    const date = new Date('2026-03-14T12:00:00Z');
+    const rfc822 = toRFC822(date);
+    assert.ok(rfc822.includes('2026'), 'Should contain year');
+    assert.ok(rfc822.includes('Mar'), 'Should contain month abbreviation');
+    assert.ok(rfc822.includes('GMT'), 'Should end with GMT');
+  });
+
+  it('only includes English posts, excludes translations', () => {
+    const posts = [
+      { id: 'welcome', data: { title: 'Welcome', description: 'D', publishedAt: new Date('2026-01-01'), tags: [] } },
+      { id: 'zh/welcome', data: { title: 'Welcome ZH', description: 'D', publishedAt: new Date('2026-01-01'), locale: 'zh', tags: [] } },
+      { id: 'ja/welcome', data: { title: 'Welcome JA', description: 'D', publishedAt: new Date('2026-01-01'), locale: 'ja', tags: [] } },
+    ];
+    const xml = generateRssXml(posts);
+    assert.ok(xml.includes('<title>Welcome</title>'));
+    assert.ok(!xml.includes('<title>Welcome ZH</title>'));
+    assert.ok(!xml.includes('<title>Welcome JA</title>'));
+  });
+
+  it('generates valid empty feed with no posts', () => {
+    const xml = generateRssXml([]);
+    assert.ok(xml.includes('<rss version="2.0"'));
+    assert.ok(xml.includes('</channel>'));
+    assert.ok(xml.includes('</rss>'));
+    assert.ok(!xml.includes('<item>'));
+  });
+
+  it('includes enclosure for posts with heroImageQuery', () => {
+    const posts = [
+      { id: 'with-hero', data: { title: 'Hero Post', description: 'D', publishedAt: new Date('2026-01-01'), heroImageQuery: 'privacy tools', tags: [] } },
+    ];
+    const xml = generateRssXml(posts);
+    assert.ok(xml.includes('<enclosure url="https://nologin.tools/blog/images/with-hero/hero.jpg" length="0" type="image/jpeg" />'));
+  });
+
+  it('does not include enclosure for posts without heroImageQuery', () => {
+    const posts = [
+      { id: 'no-hero', data: { title: 'No Hero', description: 'D', publishedAt: new Date('2026-01-01'), tags: [] } },
+    ];
+    const xml = generateRssXml(posts);
+    assert.ok(!xml.includes('<enclosure'));
+  });
+
+  it('escapes XML special characters in title and description', () => {
+    const posts = [
+      { id: 'special', data: { title: 'A & B <test>', description: 'Use "quotes" & \'apostrophes\'', publishedAt: new Date('2026-01-01'), tags: [] } },
+    ];
+    const xml = generateRssXml(posts);
+    assert.ok(xml.includes('A &amp; B &lt;test&gt;'));
+    assert.ok(xml.includes('Use &quot;quotes&quot; &amp; &apos;apostrophes&apos;'));
+  });
+
+  it('includes atom:link self reference', () => {
+    const xml = generateRssXml([]);
+    assert.ok(xml.includes('atom:link href="https://nologin.tools/rss.xml" rel="self"'));
+  });
+
+  it('includes correct channel link', () => {
+    const xml = generateRssXml([]);
+    assert.ok(xml.includes('<link>https://nologin.tools/blog</link>'));
+  });
+});

--- a/scripts/__tests__/sitemap.test.mjs
+++ b/scripts/__tests__/sitemap.test.mjs
@@ -49,6 +49,7 @@ function expandToAllLocales(pages, blogTranslationMap) {
           lastmod: page.lastmod,
           englishPath: page.url,
           availableLocales,
+          imageUrl: page.imageUrl,
         });
       }
     } else {
@@ -59,6 +60,7 @@ function expandToAllLocales(pages, blogTranslationMap) {
           changefreq: page.changefreq,
           lastmod: page.lastmod,
           englishPath: page.url,
+          imageUrl: page.imageUrl,
         });
       }
     }
@@ -254,5 +256,30 @@ describe('generateHreflangLinks', () => {
     const result = generateHreflangLinks('/', siteUrl);
     assert.ok(result.includes('hreflang="en" href="https://nologin.tools/"'));
     assert.ok(result.includes('hreflang="zh" href="https://nologin.tools/zh/"'));
+  });
+});
+
+describe('sitemap image extension', () => {
+  it('expandToAllLocales passes through imageUrl for non-blog pages', () => {
+    const pages = [{ url: '/tool/test', priority: '0.8', changefreq: 'weekly', imageUrl: '/api/og/test' }];
+    const entries = expandToAllLocales(pages);
+    assert.equal(entries.length, 8);
+    assert.ok(entries.every((e) => e.imageUrl === '/api/og/test'));
+  });
+
+  it('expandToAllLocales passes through imageUrl for blog posts', () => {
+    const pages = [
+      { url: '/blog/welcome', priority: '0.7', changefreq: 'weekly', isBlogPost: true, imageUrl: '/blog/images/welcome/hero.jpg' },
+    ];
+    const blogMap = new Map([['welcome', new Set(['en', 'zh'])]]);
+    const entries = expandToAllLocales(pages, blogMap);
+    assert.equal(entries.length, 2);
+    assert.ok(entries.every((e) => e.imageUrl === '/blog/images/welcome/hero.jpg'));
+  });
+
+  it('entries without imageUrl have undefined imageUrl', () => {
+    const pages = [{ url: '/about', priority: '0.5', changefreq: 'monthly' }];
+    const entries = expandToAllLocales(pages);
+    assert.ok(entries.every((e) => e.imageUrl === undefined));
   });
 });

--- a/src/components/BadgeInfoPage.astro
+++ b/src/components/BadgeInfoPage.astro
@@ -54,6 +54,18 @@ await loadTranslations(locale);
       },
     ],
   })} />
+  <script type="application/ld+json" set:html={JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'HowTo',
+    name: t(locale, 'badge.howToName'),
+    description: t(locale, 'badge.joinDesc'),
+    step: [
+      { '@type': 'HowToStep', position: 1, name: t(locale, 'badge.step1'), text: t(locale, 'badge.step1'), url: `https://nologin.tools${getLocalizedPath('/submit', locale)}` },
+      { '@type': 'HowToStep', position: 2, name: t(locale, 'badge.step2'), text: t(locale, 'badge.step2') },
+      { '@type': 'HowToStep', position: 3, name: t(locale, 'badge.step3'), text: t(locale, 'badge.step3') },
+      { '@type': 'HowToStep', position: 4, name: t(locale, 'badge.step4'), text: t(locale, 'badge.step4') },
+    ],
+  })} />
 
   <div class="max-w-4xl mx-auto px-6 py-16 sm:py-24">
     <!-- Hero -->

--- a/src/components/BlogListPage.astro
+++ b/src/components/BlogListPage.astro
@@ -60,6 +60,15 @@ function getPostSlug(postId: string): string {
   // For locale posts like "zh/welcome", strip the locale prefix
   return postId.includes('/') ? postId.split('/').slice(1).join('/') : postId;
 }
+
+const breadcrumbLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: t(locale, 'common.home'), item: `https://nologin.tools${getLocalizedPath('/', locale)}` },
+    { '@type': 'ListItem', position: 2, name: t(locale, 'blog.title'), item: `https://nologin.tools${getLocalizedPath('/blog', locale)}` },
+  ],
+};
 ---
 
 <Layout
@@ -68,8 +77,22 @@ function getPostSlug(postId: string): string {
   locale={locale}
 >
   <script type="application/ld+json" set:html={JSON.stringify(blogLd)} />
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbLd)} />
 
   <div class="max-w-4xl mx-auto px-4 sm:px-6 py-12 sm:py-20">
+    <!-- Breadcrumb -->
+    <nav aria-label="Breadcrumb" class="mb-8">
+      <ol class="flex items-center gap-2 text-sm font-bold text-neutral-400">
+        <li>
+          <a href={getLocalizedPath('/', locale)} class="hover:text-neutral-900 transition-colors">{t(locale, 'common.home')}</a>
+        </li>
+        <li aria-hidden="true">
+          <svg class="w-4 h-4 text-neutral-300" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" /></svg>
+        </li>
+        <li aria-current="page" class="text-neutral-900">{t(locale, 'blog.title')}</li>
+      </ol>
+    </nav>
+
     <header class="mb-12 border-b-4 border-neutral-900 pb-6">
       <h1 class="text-3xl sm:text-4xl font-black text-neutral-900 tracking-tight uppercase italic">
         {t(locale, 'blog.heading')}

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -30,6 +30,10 @@ await loadTranslations(locale);
         rel="noopener noreferrer"
         class="text-neutral-500 hover:text-neutral-900 hover:underline decoration-2 underline-offset-4">𝕏</a
       >
+      <a
+        href="/rss.xml"
+        class="text-neutral-500 hover:text-neutral-900 hover:underline decoration-2 underline-offset-4">RSS</a
+      >
       <span class="text-neutral-400">{t(locale, 'footer.mitLicense')}</span>
     </div>
     <div class="text-[10px] text-neutral-400 text-center sm:text-right font-bold uppercase tracking-tighter">

--- a/src/components/ToolDetailPage.astro
+++ b/src/components/ToolDetailPage.astro
@@ -108,6 +108,9 @@ const jsonLd = {
     availability: 'https://schema.org/InStock',
   },
   ...(approvedDate ? { datePublished: approvedDate } : {}),
+  ...(tool.githubUpdatedAt
+    ? { dateModified: new Date(tool.githubUpdatedAt).toISOString().split('T')[0] }
+    : approvedDate ? { dateModified: approvedDate } : {}),
   ...(sameAs.length > 0 ? { sameAs } : {}),
   ...(keywords ? { keywords } : {}),
 };

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -191,6 +191,7 @@
   "badge.digitalPreservationDesc": "Verified tools are archived to ensure long-term transparency.",
   "badge.joinTitle": "Join the Directory",
   "badge.joinDesc": "Building a privacy-first tool? Get recognized for your commitment to a registration-free experience.",
+  "badge.howToName": "How to Get the NoLogin Verified Badge",
   "badge.step1": "Submit your tool details",
   "badge.step2": "Verification review (~48h)",
   "badge.step3": "Approval & Directory listing",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -15,6 +15,7 @@ interface Props {
   hideHeader?: boolean;
   canonicalOverride?: string;
   publishedTime?: string;
+  modifiedTime?: string;
   locale?: Locale;
 }
 
@@ -28,6 +29,7 @@ const {
   hideHeader = false,
   canonicalOverride,
   publishedTime,
+  modifiedTime,
   locale = DEFAULT_LOCALE,
 } = Astro.props;
 
@@ -64,6 +66,7 @@ const hreflangLinks = LOCALES.map((l) => ({
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="sitemap" href="/sitemap.xml" />
+    <link rel="alternate" type="application/rss+xml" title="nologin.tools Blog" href="/rss.xml" />
     <link rel="preconnect" href="https://www.google.com" />
     <link rel="dns-prefetch" href="https://www.google.com" />
     <link rel="manifest" href="/site.webmanifest" />
@@ -88,6 +91,9 @@ const hreflangLinks = LOCALES.map((l) => ({
     {ogType === 'article' && publishedTime && (
       <meta property="article:published_time" content={publishedTime} />
       <meta property="article:section" content="Tools" />
+    )}
+    {ogType === 'article' && modifiedTime && (
+      <meta property="article:modified_time" content={modifiedTime} />
     )}
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@nologin_tools" />

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -8,6 +8,8 @@ export interface SitemapPage {
   lastmod?: string;
   /** If true, this is a blog post page (locale availability may be limited) */
   isBlogPost?: boolean;
+  /** Optional image URL for image sitemap extension */
+  imageUrl?: string;
 }
 
 export interface SitemapEntry {
@@ -19,6 +21,8 @@ export interface SitemapEntry {
   englishPath: string;
   /** Available locales for hreflang (undefined = all locales) */
   availableLocales?: Set<Locale>;
+  /** Optional image URL for image sitemap extension */
+  imageUrl?: string;
 }
 
 /**
@@ -82,6 +86,7 @@ export function expandToAllLocales(
           lastmod: page.lastmod,
           englishPath: page.url,
           availableLocales,
+          imageUrl: page.imageUrl,
         });
       }
     } else {
@@ -93,6 +98,7 @@ export function expandToAllLocales(
           changefreq: page.changefreq,
           lastmod: page.lastmod,
           englishPath: page.url,
+          imageUrl: page.imageUrl,
         });
       }
     }

--- a/src/pages/[lang]/blog/[slug].astro
+++ b/src/pages/[lang]/blog/[slug].astro
@@ -48,6 +48,12 @@ function formatDate(date: Date): string {
 const publishedDate = formatDate(post.data.publishedAt);
 const modifiedDate = post.data.updatedAt ? formatDate(post.data.updatedAt) : undefined;
 
+// Hero image OG — use originalSlug for translated posts
+const originalSlug = post.data.originalSlug || getPostSlug(post.id);
+const heroImagePath = `/blog/images/${originalSlug}/hero.jpg`;
+const hasHeroImage = !!post.data.heroImageQuery;
+const ogImageForPost = hasHeroImage ? heroImagePath : '/og-default.png';
+
 const allPosts = await getCollection('blog');
 const related = allPosts
   .filter((p) => p.id !== post.id && p.data.tags.some((tag: string) => post.data.tags.includes(tag)))
@@ -66,7 +72,7 @@ const postLd = {
   datePublished: publishedDate,
   ...(modifiedDate ? { dateModified: modifiedDate } : {}),
   url: `https://nologin.tools/blog/${getPostSlug(post.id)}`,
-  image: 'https://nologin.tools/og-default.png',
+  image: `https://nologin.tools${ogImageForPost}`,
   author: {
     '@type': 'Organization',
     name: post.data.author,
@@ -98,7 +104,9 @@ const breadcrumbLd = {
   title={post.data.title}
   description={post.data.description}
   ogType="article"
+  ogImage={ogImageForPost}
   publishedTime={publishedDate}
+  modifiedTime={modifiedDate}
   locale={locale}
 >
   <script type="application/ld+json" set:html={JSON.stringify(postLd)} />

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -25,6 +25,11 @@ function formatDate(date: Date): string {
 const publishedDate = formatDate(post.data.publishedAt);
 const modifiedDate = post.data.updatedAt ? formatDate(post.data.updatedAt) : undefined;
 
+// Hero image OG
+const heroImagePath = `/blog/images/${post.id}/hero.jpg`;
+const hasHeroImage = !!post.data.heroImageQuery;
+const ogImageForPost = hasHeroImage ? heroImagePath : '/og-default.png';
+
 // Related posts: same tags
 const allPosts = await getCollection('blog');
 const related = allPosts
@@ -40,7 +45,7 @@ const postLd = {
   datePublished: publishedDate,
   ...(modifiedDate ? { dateModified: modifiedDate } : {}),
   url: `https://nologin.tools/blog/${post.id}`,
-  image: 'https://nologin.tools/og-default.png',
+  image: `https://nologin.tools${ogImageForPost}`,
   author: {
     '@type': 'Organization',
     name: post.data.author,
@@ -72,7 +77,9 @@ const breadcrumbLd = {
   title={post.data.title}
   description={post.data.description}
   ogType="article"
+  ogImage={ogImageForPost}
   publishedTime={publishedDate}
+  modifiedTime={modifiedDate}
   locale={locale}
 >
   <script type="application/ld+json" set:html={JSON.stringify(postLd)} />

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,62 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+function toRFC822(date: Date): string {
+  return date.toUTCString();
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export const GET: APIRoute = async () => {
+  const siteUrl = import.meta.env.SITE?.replace(/\/$/, '') || 'https://nologin.tools';
+
+  const allPosts = await getCollection('blog');
+  const englishPosts = allPosts
+    .filter((p) => !p.id.includes('/'))
+    .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
+
+  const items = englishPosts
+    .map((post) => {
+      const link = escapeXml(`${siteUrl}/blog/${post.id}`);
+      const enclosure = post.data.heroImageQuery
+        ? `\n      <enclosure url="${escapeXml(`${siteUrl}/blog/images/${post.id}/hero.jpg`)}" length="0" type="image/jpeg" />`
+        : '';
+      return `    <item>
+      <title>${escapeXml(post.data.title)}</title>
+      <link>${link}</link>
+      <description>${escapeXml(post.data.description)}</description>
+      <pubDate>${toRFC822(post.data.publishedAt)}</pubDate>
+      <guid>${link}</guid>${enclosure}
+    </item>`;
+    })
+    .join('\n');
+
+  const lastBuildDate = englishPosts.length > 0 ? toRFC822(englishPosts[0].data.publishedAt) : toRFC822(new Date());
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>nologin.tools Blog</title>
+    <link>${siteUrl}/blog</link>
+    <description>Privacy-friendly tools that work without login — reviews, guides, and updates.</description>
+    <language>en</language>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+    <atom:link href="${siteUrl}/rss.xml" rel="self" type="application/rss+xml" />
+${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/xml',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+};

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -32,6 +32,7 @@ export const GET: APIRoute = async () => {
     priority: '0.8',
     changefreq: 'weekly',
     lastmod: t.approvedAt ? new Date(t.approvedAt).toISOString().split('T')[0] : undefined,
+    imageUrl: `/api/og/${t.slug}`,
   }));
 
   const badgePages: SitemapPage[] = approvedTools.map((t) => ({
@@ -56,6 +57,7 @@ export const GET: APIRoute = async () => {
     changefreq: 'weekly',
     lastmod: (post.data.updatedAt || post.data.publishedAt).toISOString().split('T')[0],
     isBlogPost: true,
+    imageUrl: post.data.heroImageQuery ? `/blog/images/${post.id}/hero.jpg` : undefined,
   }));
 
   // Expand all pages to multi-locale entries
@@ -72,14 +74,15 @@ export const GET: APIRoute = async () => {
 
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
 ${allEntries
   .map(
     (entry) => `  <url>
     <loc>${siteUrl}${entry.url}</loc>${entry.lastmod ? `\n    <lastmod>${entry.lastmod}</lastmod>` : ''}
     <changefreq>${entry.changefreq}</changefreq>
     <priority>${entry.priority}</priority>
-${generateHreflangLinks(entry.englishPath, siteUrl, entry.availableLocales)}
+${generateHreflangLinks(entry.englishPath, siteUrl, entry.availableLocales)}${entry.imageUrl ? `\n    <image:image>\n      <image:loc>${siteUrl}${entry.imageUrl}</image:loc>\n    </image:image>` : ''}
   </url>`
   )
   .join('\n')}


### PR DESCRIPTION
## Summary

- **RSS Feed**: New `rss.xml.ts` with RSS 2.0, atom:link self-reference, hero image enclosures, XML escaping. RSS link added to Layout `<head>` and Footer.
- **Cache-Control Headers**: Long-term cache for `/_astro/*` (1yr immutable), `/blog/images/*` (30d), `/favicon.svg`, `/og-default.png`, `/badges/*` (7d).
- **`article:modified_time`**: New `modifiedTime` prop on Layout, passed from blog pages when `updatedAt` exists.
- **Blog List Breadcrumb**: Visual breadcrumb nav + BreadcrumbList JSON-LD on BlogListPage.
- **HowTo Schema**: Badge info page now has HowTo JSON-LD alongside FAQPage, with i18n support via `badge.howToName` key.
- **Blog Hero as OG Image**: Blog posts with `heroImageQuery` use `/blog/images/{slug}/hero.jpg` as OG image (both en and i18n pages use `originalSlug` for translated posts).
- **Sitemap Image Extension**: `xmlns:image` namespace + `<image:image>` tags for tool OG images and blog hero images.
- **ToolDetail `dateModified`**: SoftwareApplication JSON-LD now includes `dateModified` (from `githubUpdatedAt` or `approvedAt`).

## Test plan

- [x] `node --test scripts/__tests__/rss.test.mjs` — 10 cases pass
- [x] `node --test scripts/__tests__/headers.test.mjs` — 8 cases pass
- [x] `node --test scripts/__tests__/sitemap.test.mjs` — 23 cases pass (3 new image cases)
- [x] `pnpm build` with mock data succeeds
- [ ] Verify `/rss.xml` returns valid RSS XML in browser
- [ ] Google Rich Results Test: blog list (BreadcrumbList), badge info (HowTo + FAQPage), tool detail (SoftwareApplication with dateModified)
- [ ] Chrome DevTools Network: `/_astro/` resources have `immutable` cache header