### PR TITLE
fix(discovery): use git diff instead of find for tool JSON detection

### DIFF
--- a/.github/workflows/tool-discoverer.yml
+++ b/.github/workflows/tool-discoverer.yml
@@ -97,7 +97,9 @@ jobs:
           git checkout "$BRANCH"
 
           # --- 2. Check for skip file (no tool found) ---
-          SKIP_FILE=$(find .github/auto-tools -name "_skip-*" 2>/dev/null | head -1)
+          # Use git diff to only find files NEW in this branch (not inherited from main)
+          SKIP_FILE=$(git diff --name-only --diff-filter=A origin/main..."$BRANCH" \
+            -- '.github/auto-tools/_skip-*' | head -1)
           if [ -n "$SKIP_FILE" ]; then
             REASON=$(cat "$SKIP_FILE")
             echo "No suitable tool found: $REASON"
@@ -107,11 +109,11 @@ jobs:
             exit 0
           fi
 
-          # --- 3. Find and validate tool JSON ---
-          TOOL_JSON=$(find .github/auto-tools -name "*.json" -not -name "_*" \
-            2>/dev/null | sort -r | head -1)
+          # --- 3. Find and validate tool JSON (only NEW files in this branch) ---
+          TOOL_JSON=$(git diff --name-only --diff-filter=A origin/main..."$BRANCH" \
+            -- '.github/auto-tools/*.json' | head -1)
           if [ -z "$TOOL_JSON" ]; then
-            echo "No tool data JSON found"
+            echo "No NEW tool data JSON found in this branch"
             gh issue comment "$ISSUE_NUMBER" \
               --body "No tool data file found in the branch."
             gh issue close "$ISSUE_NUMBER"
@@ -154,7 +156,7 @@ jobs:
             fi
           fi
 
-          # --- 6. Clean up old auto-tool data files from previous runs ---
+          # --- 6. Clean up old auto-tool data files inherited from main ---
           OLD_FILES=$(find .github/auto-tools -name "*.json" \
             -not -name "$(basename "$TOOL_JSON")" -not -name "_*" \
             2>/dev/null || true)


### PR DESCRIPTION
## Problem

The tool discoverer post-processing used `find .github/auto-tools` to locate tool JSON files. This picks up **old files inherited from main**, not just files created by Claude in the current run.

**What happened** (PR #57 → #61):
1. PR #57 merged `phet-colorado-edu.json` into main
2. Issue #60 triggered — Claude found `learngitbranching` and created both blog + tool JSON
3. `find | sort -r | head -1` found **two** JSON files, picked the old `phet-colorado-edu.json` (alphabetically later)
4. `TOOL_JSON` pointed to old file → D1 submit skipped (dedup) → PR titled "Tool: PhET Interactive Simulations"
5. Cleanup step deleted all JSON except `TOOL_JSON` → **`learngitbranching-js-org.json` was deleted**
6. learngitbranching was **never submitted to D1**

Evidence from CI logs:
```
Found tool data: .github/auto-tools/phet-colorado-edu.json
[submit-tool] Tool with slug "phet-colorado-edu" already exists (id: 141), skipping.
rm '.github/auto-tools/learngitbranching-js-org.json'    ← new file deleted by cleanup
```

## Fix

Replace `find .github/auto-tools` with `git diff --name-only --diff-filter=A origin/main...$BRANCH` for steps 2 (skip file) and 3 (tool JSON). This ensures only files **newly added by Claude** are detected.

The cleanup step (step 6) still uses `find` intentionally — it removes old files inherited from main.

## Test Plan
- [x] YAML syntax validated
- [ ] Next auto-tool run picks up only its own JSON