### PR TITLE
Add Kindle Highlights Exporter, Subtitle Converter, and WhatsApp Chat Formatter

### DIFF
--- a/.github/auto-tools/xueboyang1985-github-io-kindle-exporter.json
+++ b/.github/auto-tools/xueboyang1985-github-io-kindle-exporter.json
@@ -1,0 +1,36 @@
+{
+    "coreTask":  "Extract Kindle highlights and notes from My Clippings.txt into structured formats",
+    "url":  "https://xueboyang1985.github.io/kindle-exporter/",
+    "name":  "Kindle Highlights Exporter",
+    "description":  "Export Kindle highlights and notes to Markdown, CSV, or JSON. 100% browser-based, no upload required - your data never leaves your device.",
+    "tags":  [
+                 {
+                     "key":  "category",
+                     "value":  "Productivity"
+                 },
+                 {
+                     "key":  "data",
+                     "value":  "Client-Side Only"
+                 },
+                 {
+                     "key":  "privacy",
+                     "value":  "Privacy Focused"
+                 },
+                 {
+                     "key":  "type",
+                     "value":  "Web App"
+                 },
+                 {
+                     "key":  "hosting",
+                     "value":  "Cloud Only"
+                 },
+                 {
+                     "key":  "offline",
+                     "value":  "Works Offline"
+                 },
+                 {
+                     "key":  "pricing",
+                     "value":  "Freemium"
+                 }
+             ]
+}

--- a/.github/auto-tools/xueboyang1985-github-io-subtitle-converter.json
+++ b/.github/auto-tools/xueboyang1985-github-io-subtitle-converter.json
@@ -1,0 +1,28 @@
+{
+    "coreTask":  "Convert subtitle formats and extract transcript text from SRT/VTT/ASS files",
+    "url":  "https://xueboyang1985.github.io/subtitle-converter/",
+    "name":  "Subtitle Converter",
+    "description":  "Convert SRT, VTT, and ASS subtitle files to TXT, Markdown, CSV, or JSON directly in your browser. No upload, 100% client-side.",
+    "tags":  [
+                 {
+                     "key":  "category",
+                     "value":  "Media"
+                 },
+                 {
+                     "key":  "data",
+                     "value":  "Client-Side Only"
+                 },
+                 {
+                     "key":  "privacy",
+                     "value":  "Privacy Focused"
+                 },
+                 {
+                     "key":  "type",
+                     "value":  "Web App"
+                 },
+                 {
+                     "key":  "pricing",
+                     "value":  "Freemium"
+                 }
+             ]
+}

--- a/.github/auto-tools/xueboyang1985-github-io-whatsapp-chat-formatter.json
+++ b/.github/auto-tools/xueboyang1985-github-io-whatsapp-chat-formatter.json
@@ -1,0 +1,28 @@
+{
+    "coreTask":  "Convert WhatsApp chat export .txt files into readable and structured formats",
+    "url":  "https://xueboyang1985.github.io/whatsapp-chat-formatter/",
+    "name":  "WhatsApp Chat Formatter",
+    "description":  "Format WhatsApp chat exports into clean Markdown, HTML, TXT, CSV, or JSON. 100% browser-based, no upload, privacy first.",
+    "tags":  [
+                 {
+                     "key":  "category",
+                     "value":  "Productivity"
+                 },
+                 {
+                     "key":  "data",
+                     "value":  "Client-Side Only"
+                 },
+                 {
+                     "key":  "privacy",
+                     "value":  "Privacy Focused"
+                 },
+                 {
+                     "key":  "type",
+                     "value":  "Web App"
+                 },
+                 {
+                     "key":  "pricing",
+                     "value":  "Freemium"
+                 }
+             ]
+}


### PR DESCRIPTION
Added three no-login browser tools discovered via GitHub:

1. **Kindle Highlights Exporter** (Productivity) - Export Kindle highlights to Markdown, CSV, JSON
2. **Subtitle Converter** (Media) - Convert SRT/VTT/ASS to TXT, MD, CSV, JSON
3. **WhatsApp Chat Formatter** (Productivity) - Format WhatsApp exports to MD, HTML, CSV, JSON, TXT

All tools: 100% browser-based, no upload, privacy-first, works offline.